### PR TITLE
Allow null limit and offset in CustomersApi->_list

### DIFF
--- a/lib/CustomersApi.php
+++ b/lib/CustomersApi.php
@@ -66,7 +66,7 @@ class CustomersApi {
    * @param int $offset How many results to skip. (required)
    * @return CustomerListResponse
    */
-   public function _list($limit, $offset) {
+   public function _list($limit = null, $offset = null) {
       
 
       // parse inputs


### PR DESCRIPTION
If testing for null values on line 87, these should be allowed to be null when calling the method

Also, this line in the readme will fail:

`$myCusties = $customersApi->_list(10);`
