### PR TITLE
Add boolean type to fix deserialization

### DIFF
--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -434,7 +434,7 @@ class ApiClient {
       $deserialized = $values;
     } elseif ($class == 'DateTime') {
       $deserialized = new \DateTime($data);
-    } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool', 'object'))) {
+    } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool', 'boolean', 'object'))) {
       settype($data, $class);
       $deserialized = $data;
     } else {


### PR DESCRIPTION
When deleting a funding source ApiClient tries to load `boolean` as a model:
`Fatal error:  Class 'DwollaSwagger\models\boolean' not found in dwolla/dwollaswagger/lib/ApiClient.php`

Fixed by adding `boolean` to the list of types.
