### PR TITLE
Add control over IPV4 and V6 connections

### DIFF
--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -281,6 +281,11 @@ class ApiClient {
     // obtain the HTTP response headers
     curl_setopt($curl, CURLOPT_HEADER, 1);
 
+    // force IPV4 only, if needed
+    if (!Configuration::$allowIPV6 && defined('CURLOPT_IPRESOLVE') && defined('CURL_IPRESOLVE_V4')) {
+      curl_setopt($curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+    }
+
     // Make the request
     $response = curl_exec($curl);
     $http_header_size = curl_getinfo($curl, CURLINFO_HEADER_SIZE);

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -65,7 +65,7 @@ class Configuration {
   public static $allowIPV6 = true;
 
   /*
-   *  manually initalize  ApiClient
+   *  manually initialize  ApiClient
    */
   public static function init() {
     if (self::$apiClient === null)

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -59,6 +59,11 @@ class Configuration {
    */
   public static $debug_file = 'php://output';
 
+  /**
+   * Control over IPV4 and 6 routing
+   */
+  public static $allowIPV6 = true;
+
   /*
    *  manually initalize  ApiClient
    */


### PR DESCRIPTION
Some servers/networks have issues if cloudflare returns an IPV6 address when resolving ```api.dwolla.com```

```
* Hostname was NOT found in DNS cache
*   Trying 2400:cb00:2048:1::6814:30f5...
* Immediate connect fail for 2400:cb00:2048:1::6814:30f5: Network is unreachable
*   Trying 2400:cb00:2048:1::6814:2ff5...
* Immediate connect fail for 2400:cb00:2048:1::6814:2ff5: Network is unreachable
* Closing connection 172
[DEBUG] HTTP Request body  ~BEGIN~
```

This allows for the configuration (and disabling of IPV6 curl calls) if using a server/network with known issues with IPV6

