### PR TITLE
Removes requirement for $removed in getCustomerFundingSources

### DIFF
--- a/lib/FundingsourcesApi.php
+++ b/lib/FundingsourcesApi.php
@@ -136,7 +136,7 @@ class FundingsourcesApi {
    * @param boolean $removed Filter funding sources by this value. (optional)
    * @return FundingSourceListResponse
    */
-   public function getCustomerFundingSources($id, $removed) {
+   public function getCustomerFundingSources($id, $removed = null) {
       
       // verify the required parameter 'id' is set
       if ($id === null) {

--- a/lib/FundingsourcesApi.php
+++ b/lib/FundingsourcesApi.php
@@ -66,7 +66,7 @@ class FundingsourcesApi {
    * @param boolean $removed Filter funding sources by this value. (optional)
    * @return FundingSourceListResponse
    */
-   public function getAccountFundingSources($id, $removed) {
+   public function getAccountFundingSources($id, $removed = null) {
       
       // verify the required parameter 'id' is set
       if ($id === null) {


### PR DESCRIPTION
The current doc's don't show that you need a boolean to get customers funding sources. 

This fix allows the value to be null, much like other calls in the API. 

[Current Docs on Website](https://docsv2.dwolla.com/#list-funding-sources-for-a-customer)

[SDK Function Declaration parameter definition](https://github.com/Dwolla/dwolla-swagger-php/blob/master/lib/FundingsourcesApi.php#L66)