### PR TITLE
Fix HTTP2 throwing error while parsing HTTP Location header

### DIFF
--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -304,7 +304,7 @@ class ApiClient {
     } else if ($response_info['http_code'] >= 200 && $response_info['http_code'] <= 299 ) {
       $data = json_decode($http_body);
       if ($response_info['http_code'] == 201) {
-        $data = is_null(self::http_parse_headers($http_header)["Location"])
+        $data = !isset(self::http_parse_headers($http_header)["Location"])
         ? self::http_parse_headers($http_header)["location"]
         : self::http_parse_headers($http_header)["Location"];
       }


### PR DESCRIPTION
The problem was, that is_null method throws "Undefined index: Location" ErrorException, while trying to parse HTTP2 headers, which are all in lower case.
This code will fix that issue.