### PR TITLE
Update minimum revision to 5.4.0 to match coding style

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }
   ],
   "require": {
-    "php": ">=5.3.3",
+    "php": ">=5.4.0",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*"


### PR DESCRIPTION
This is in response to Issue #32 which points out that there is invalid code within the code-base for PHP 5.3.3, which is the required minimum version. 

This could be a potentially breaking change for some people, that being said, the code being run shouldn't actually work for someone who consumed the API on PHP 5.3.3. 

For example, declaring an array using short notation `$names = ['Foo', 'Bar'];` was not supported until 5.4.0.