### PR TITLE
Clean Up Documentation for Issue 28

### DIFF
--- a/lib/AccountsApi.php
+++ b/lib/AccountsApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class AccountsApi {
 
+  /**
+   * @var ApiClient $apiClient instance fo the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -39,8 +49,6 @@ class AccountsApi {
     // Authentication methods
     $this->authSettings = array('oauth2');
   }
-
-  private $apiClient; // instance of the ApiClient
 
   /**
    * get the API client
@@ -63,7 +71,8 @@ class AccountsApi {
    * Get account info by id.
    *
    * @param string $id Account ID to get info for. (required)
-   * @return FullAccountInfo
+   * @return models\FullAccountInfo
+   * @throws ApiException
    */
    public function id($id) {
       
@@ -129,7 +138,8 @@ class AccountsApi {
    * Create an OAuth token that is capable of adding a financial institution for the given account.
    *
    * @param string $id Account ID to create token for. (required)
-   * @return AccountOAuthToken
+   * @return models\AccountOAuthToken
+   * @throws ApiException
    */
    public function createFundingSourcesToken($id) {
       

--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -368,7 +368,7 @@ class ApiClient {
    * the query, by imploding comma-separated if it's an object.
    * If it's a string, pass through unchanged. It will be url-encoded
    * later.
-   * @param object $object an object to be serialized to a string
+   * @param object|string|int $object an object to be serialized to a string
    * @return string the serialized object
    */
   public static function toQueryValue($object) {

--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -27,23 +27,26 @@ class ApiClient {
   
   private static $default_header = array();
 
-  /*
+  /**
    * @var string timeout (second) of the HTTP request, by default set to 0, no timeout
    */
   protected $curl_timeout = 0;
 
-  /*
+  /**
    * @var string user agent of the HTTP request, set to "PHP-Swagger" by default
    */
   protected $user_agent = "PHP-Swagger";
 
   /**
+   * @var string Base url of the API server
+   */
+  protected $host = 'https://localhost';
+
+  /**
    * @param string $host Base url of the API server (optional)
    */
   function __construct($host = null) {
-    if ($host === null) {
-      $this->host = 'https://localhost';
-    } else {
+    if (!is_null($host)) {
       $this->host = rtrim($host, "/");
     }
   }
@@ -129,7 +132,8 @@ class ApiClient {
 
   /**
    * get the user agent of the api client
-   * 
+   *
+   * @param string $user_agent user agent of the HTTP request. Not currently used.
    * @return string user agent
    */
   public function getUserAgent($user_agent) {
@@ -161,7 +165,7 @@ class ApiClient {
   /**
    * Get API key (with prefix if set)
    * @param string key name
-   * @return string API key with the prefix
+   * @return string|null API key with the prefix
    */
   public function getApiKeyWithPrefix($apiKey) {
     if (isset(Configuration::$apiKeyPrefix[$apiKey])) {
@@ -169,7 +173,7 @@ class ApiClient {
     } else if (isset(Configuration::$apiKey[$apiKey])) {
       return Configuration::$apiKey[$apiKey];
     } else {
-      return;
+      return null;
     }
   }
 
@@ -177,7 +181,7 @@ class ApiClient {
    * update hearder and query param based on authentication setting
    * 
    * @param array $headerParams header parameters (by ref)
-   * @param array $queryParams query parameters (by ref)
+   * @param array $queryParams query parameters (by ref). Parameter is not used.
    * @param array $authSettings array of authentication scheme (e.g ['api_key'])
    */
   public function updateParamsForAuth(&$headerParams, &$queryParams, $authSettings)
@@ -207,6 +211,8 @@ class ApiClient {
    * @param array $queryParams parameters to be place in query URL
    * @param array $postData parameters to be placed in POST body
    * @param array $headerParams parameters to be place in request header
+   * @param array $authSettings array of authentication scheme (e.g ['api_key'])
+   * @throws ApiException
    * @return mixed
    */
   public function callApi($resourcePath, $method, $queryParams, $postData,
@@ -414,7 +420,7 @@ class ApiClient {
   /**
    * Deserialize a JSON string into an object
    *
-   * @param object $object object or primitive to be deserialized
+   * @param object $data object or primitive to be deserialized
    * @param string $class class name is passed as a string
    * @return object an instance of $class
    */

--- a/lib/BeneficialownersApi.php
+++ b/lib/BeneficialownersApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class BeneficialownersApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class BeneficialownersApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -60,10 +73,11 @@ class BeneficialownersApi {
   /**
    * getById
    *
-   * Get an beneficial owner by ID
+   * Get a beneficial owner by ID
    *
    * @param string $id ID of owner to lookup (required)
-   * @return Owner
+   * @return models\Owner
+   * @throws ApiException
    */
    public function getById($id) {
 
@@ -128,9 +142,10 @@ class BeneficialownersApi {
    *
    * Update a beneficial owner.
    *
-   * @param UpdateOwnerRequest $body Owner to update. (required)
+   * @param models\UpdateOwnerRequest $body Owner to update. (required)
    * @param string $id ID of owner to update (required)
-   * @return Owner
+   * @return models\Owner
+   * @throws ApiException
    */
    public function update($body, $id) {
 
@@ -197,10 +212,11 @@ class BeneficialownersApi {
   /**
    * getBeneficialOwnerDocuments
    *
-   * Get documents uploaded for beneficial owner.
+   * Get documents uploaded for a beneficial owner.
    *
    * @param string $id ID of owner. (required)
-   * @return DocumentListResponse
+   * @return models\DocumentListResponse
+   * @throws ApiException
    */
    public function getBeneficialOwnerDocuments($id) {
 
@@ -266,7 +282,8 @@ class BeneficialownersApi {
    * Delete a beneficial owner by id.
    *
    * @param string $id ID of beneficial owner to delete. (required)
-   * @return Owner
+   * @return models\Owner
+   * @throws ApiException
    */
    public function deleteById($id) {
 

--- a/lib/BusinessclassificationsApi.php
+++ b/lib/BusinessclassificationsApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class BusinessclassificationsApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class BusinessclassificationsApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -62,7 +75,8 @@ class BusinessclassificationsApi {
    *
    * Get a list business classifications.
    *
-   * @return BusinessClassificationListResponse
+   * @return models\BusinessClassificationListResponse
+   * @throws ApiException
    */
    public function _list() {
       
@@ -113,7 +127,8 @@ class BusinessclassificationsApi {
    * Get a business classification with a list of industry classifications.
    *
    * @param string $id Id of business classification to get. (required)
-   * @return BusinessClassification
+   * @return models\BusinessClassification
+   * @throws ApiException
    */
    public function getBusinessClassification($id) {
       

--- a/lib/CustomersApi.php
+++ b/lib/CustomersApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class CustomersApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class CustomersApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -66,7 +79,8 @@ class CustomersApi {
    * @param int $offset How many results to skip. (optional)
    * @param string $search Search term. (optional)
    * @param string $status Customer status. (optional)
-   * @return CustomerListResponse
+   * @return models\CustomerListResponse
+   * @throws ApiException
    */
    public function _list($limit = null, $offset = null, $search = null, $status = null) {
 
@@ -127,8 +141,9 @@ class CustomersApi {
    *
    * Create a new customer.
    *
-   * @param CreateCustomer $body Customer to create. (required)
-   * @return Unit
+   * @param models\CreateCustomer $body Customer to create. (required)
+   * @return models\Unit
+   * @throws ApiException
    */
    public function create($body) {
 
@@ -183,7 +198,8 @@ class CustomersApi {
    * Get a customer by id
    *
    * @param string $id Id of customer to get. (required)
-   * @return Customer
+   * @return models\Customer
+   * @throws ApiException
    */
    public function getCustomer($id) {
 
@@ -248,9 +264,10 @@ class CustomersApi {
    *
    * Update customer record. Personal customer records are re-verified upon update.
    *
-   * @param UpdateCustomer $body Customer to update. (required)
+   * @param models\UpdateCustomer $body Customer to update. (required)
    * @param string $id Id of customer to update. (required)
-   * @return Customer
+   * @return models\Customer
+   * @throws ApiException
    */
    public function updateCustomer($body, $id) {
 
@@ -319,9 +336,10 @@ class CustomersApi {
    *
    * Add a beneficial owner
    *
-   * @param CreateOwnerRequest $body Beneficial owner to create. (required)
+   * @param models\CreateOwnerRequest $body Beneficial owner to create. (required)
    * @param string $id Customer id to add owner for for. (required)
-   * @return Owner
+   * @return models\Owner
+   * @throws ApiException
    */
    public function addBeneficialOwner($body, $id) {
 
@@ -391,7 +409,8 @@ class CustomersApi {
    * Get Beneficial Owners added for a customer.
    *
    * @param string $id ID of customer. (required)
-   * @return BeneficialOwnerListResponse
+   * @return models\BeneficialOwnerListResponse
+   * @throws ApiException
    */
    public function getBeneficialOwners($id) {
 
@@ -457,7 +476,8 @@ class CustomersApi {
    * Get a customer's ownership certification status.
    *
    * @param string $id Customer id to get ownership certification status for. (required)
-   * @return Ownership
+   * @return models\Ownership
+   * @throws ApiException
    */
    public function getOwnershipStatus($id) {
 
@@ -522,9 +542,10 @@ class CustomersApi {
    *
    * Change ownership status.
    *
-   * @param CertifyRequest $body Status of ownership (required)
+   * @param models\CertifyRequest $body Status of ownership (required)
    * @param string $id Customer id to change ownership status. (required)
-   * @return Ownership
+   * @return models\Ownership
+   * @throws ApiException
    */
    public function changeOwnershipStatus($body, $id) {
 
@@ -594,7 +615,8 @@ class CustomersApi {
    * Get documents uploaded for customer.
    *
    * @param string $id ID of customer. (required)
-   * @return DocumentListResponse
+   * @return models\DocumentListResponse
+   * @throws ApiException
    */
    public function getCustomerDocuments($id) {
 
@@ -660,7 +682,8 @@ class CustomersApi {
    * Upload a verification document.
    *
    * @param string $id ID of customer. (required)
-   * @return Unit
+   * @return models\Unit
+   * @throws ApiException
    */
    public function uploadDocument($id) {
 
@@ -726,7 +749,8 @@ class CustomersApi {
    * Create an OAuth token that is capable of adding a financial institution for the given customer.
    *
    * @param string $id ID of customer. (required)
-   * @return CustomerOAuthToken
+   * @return models\CustomerOAuthToken
+   * @throws ApiException
    */
    public function createFundingSourcesTokenForCustomer($id) {
 
@@ -792,7 +816,8 @@ class CustomersApi {
    * Get iav token for customer.
    *
    * @param string $id ID of customer. (required)
-   * @return IavToken
+   * @return models\IavToken
+   * @throws ApiException
    */
    public function getCustomerIavToken($id) {
 

--- a/lib/DocumentsApi.php
+++ b/lib/DocumentsApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class DocumentsApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class DocumentsApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -63,7 +76,8 @@ class DocumentsApi {
    * Get a document by id
    *
    * @param string $id Id of document to get. (required)
-   * @return Document
+   * @return models\Document
+   * @throws ApiException
    */
    public function getDocument($id) {
       

--- a/lib/EventsApi.php
+++ b/lib/EventsApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class EventsApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class EventsApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -64,7 +77,8 @@ class EventsApi {
    *
    * @param int $limit How many results to return. (optional)
    * @param int $offset How many results to skip. (optional)
-   * @return EventListResponse
+   * @return models\EventListResponse
+   * @throws ApiException
    */
    public function events($limit = null, $offset = null) {
 
@@ -121,7 +135,8 @@ class EventsApi {
    * Get an event by id.
    *
    * @param string $id ID of application event to get. (required)
-   * @return ApplicationEvent
+   * @return models\ApplicationEvent
+   * @throws ApiException
    */
    public function id($id) {
 

--- a/lib/FundingsourcesApi.php
+++ b/lib/FundingsourcesApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class FundingsourcesApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class FundingsourcesApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -64,7 +77,8 @@ class FundingsourcesApi {
    *
    * @param string $id Account id to get funding sources for. (required)
    * @param boolean $removed Filter funding sources by this value. (optional)
-   * @return FundingSourceListResponse
+   * @return models\FundingSourceListResponse
+   * @throws ApiException
    */
    public function getAccountFundingSources($id, $removed = null) {
       
@@ -134,7 +148,8 @@ class FundingsourcesApi {
    *
    * @param string $id Customer id to get funding sources for. (required)
    * @param boolean $removed Filter funding sources by this value. (optional)
-   * @return FundingSourceListResponse
+   * @return models\FundingSourceListResponse
+   * @throws ApiException
    */
    public function getCustomerFundingSources($id, $removed = null) {
       
@@ -202,9 +217,10 @@ class FundingsourcesApi {
    *
    * Create a new funding source.
    *
-   * @param CreateFundingSourceRequest $body Funding source to create. (required)
+   * @param models\CreateFundingSourceRequest $body Funding source to create. (required)
    * @param string $id Customer id to create funding source for. (required)
-   * @return FundingSource
+   * @return models\FundingSource
+   * @throws ApiException
    */
    public function createCustomerFundingSource($body, $id) {
       
@@ -273,8 +289,9 @@ class FundingsourcesApi {
    *
    * Create a new funding source.
    *
-   * @param CreateFundingSourceRequest $body Funding source to create. (required)
-   * @return FundingSource
+   * @param models\CreateFundingSourceRequest $body Funding source to create. (required)
+   * @return models\FundingSource
+   * @throws ApiException
    */
    public function createFundingSource($body) {
       
@@ -329,7 +346,8 @@ class FundingsourcesApi {
    * Get a funding source by id.
    *
    * @param string $id Funding source ID to get. (required)
-   * @return FundingSource
+   * @return models\FundingSource
+   * @throws ApiException
    */
    public function id($id) {
       
@@ -394,9 +412,10 @@ class FundingsourcesApi {
    *
    * Update a funding source.
    *
-   * @param UpdateBankRequest $body request body to update a funding source (required)
+   * @param models\UpdateBankRequest $body request body to update a funding source (required)
    * @param string $id Funding source ID to update. (required)
-   * @return FundingSource
+   * @return models\FundingSource
+   * @throws ApiException
    */
    public function update($body, $id) {
 
@@ -465,9 +484,10 @@ class FundingsourcesApi {
    *
    * Remove a funding source.
    *
-   * @param RemoveBankRequest $body request body to remove a funding source (required)
+   * @param models\RemoveBankRequest $body request body to remove a funding source (required)
    * @param string $id Funding source ID to remove. (required)
-   * @return FundingSource
+   * @return models\FundingSource
+   * @throws ApiException
    */
    public function softDelete($body, $id) {
       
@@ -537,7 +557,8 @@ class FundingsourcesApi {
    * Get the balance of a funding source.
    *
    * @param string $id Funding source ID to get the balance for. (required)
-   * @return FundingSourceBalance
+   * @return models\FundingSourceBalance
+   * @throws ApiException
    */
    public function getBalance($id) {
       
@@ -603,7 +624,8 @@ class FundingsourcesApi {
    * Verify pending verifications exist.
    *
    * @param string $id Funding source ID to check for pending validation deposits for. (required)
-   * @return MicroDepositsInitiated
+   * @return models\MicroDepositsInitiated
+   * @throws ApiException
    */
    public function verifyMicroDepositsExist($id) {
       
@@ -668,9 +690,10 @@ class FundingsourcesApi {
    *
    * Initiate or verify micro deposits for bank verification.
    *
-   * @param VerifyMicroDepositsRequest $body Optional micro deposit amounts for verification (required)
+   * @param models\VerifyMicroDepositsRequest $body Optional micro deposit amounts for verification (required)
    * @param string $id Funding source ID to initiate or verify micro deposits for. (required)
-   * @return MicroDeposits
+   * @return models\MicroDeposits
+   * @throws ApiException
    */
    public function microDeposits($body, $id) {
       

--- a/lib/MasspaymentitemsApi.php
+++ b/lib/MasspaymentitemsApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class MasspaymentitemsApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class MasspaymentitemsApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -63,7 +76,8 @@ class MasspaymentitemsApi {
    * Get a mass payment item by id.
    *
    * @param string $id ID of mass payment item to get. (required)
-   * @return MassPaymentItem
+   * @return models\MassPaymentItem
+   * @throws ApiException
    */
    public function byId($id) {
 
@@ -133,7 +147,8 @@ class MasspaymentitemsApi {
    * @param int $offset How many results to skip. (optional)
    * @param string $status What status to filter by. (optional)
    * @param string $correlation_id Correlation ID to search by. (optional)
-   * @return MassPaymentItemListResponse
+   * @return models\MassPaymentItemListResponse
+   * @throws ApiException
    */
    public function getMassPaymentItems($id, $limit = null, $offset = null, $status = null, $correlation_id = null) {
 

--- a/lib/MasspaymentsApi.php
+++ b/lib/MasspaymentsApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class MasspaymentsApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class MasspaymentsApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -66,7 +79,8 @@ class MasspaymentsApi {
    * @param int $limit How many results to return. (optional)
    * @param int $offset How many results to skip. (optional)
    * @param string $correlation_id Correlation ID to search by. (optional)
-   * @return MassPaymentListResponse
+   * @return models\MassPaymentListResponse
+   * @throws ApiException
    */
    public function getByAccount($id, $limit = null, $offset = null, $correlation_id = null) {
 
@@ -144,7 +158,8 @@ class MasspaymentsApi {
    * @param int $limit How many results to return. (optional)
    * @param int $offset How many results to skip. (optional)
    * @param string $correlation_id Correlation ID to search by. (required)
-   * @return MassPaymentListResponse
+   * @return models\MassPaymentListResponse
+   * @throws ApiException
    */
    public function getByCustomer($id, $limit = null, $offset = null, $correlation_id = null) {
 
@@ -218,8 +233,9 @@ class MasspaymentsApi {
    *
    * Create a new mass payment.
    *
-   * @param MassPaymentRequestBody $body Mass payment request. (required)
-   * @return Unit
+   * @param models\MassPaymentRequestBody $body Mass payment request. (required)
+   * @return models\Unit
+   * @throws ApiException
    */
    public function create($body) {
 
@@ -274,7 +290,8 @@ class MasspaymentsApi {
    * Get a mass payment by id.
    *
    * @param string $id ID of mass payment to get. (required)
-   * @return MassPayment
+   * @return models\MassPayment
+   * @throws ApiException
    */
    public function byId($id) {
 
@@ -339,9 +356,10 @@ class MasspaymentsApi {
    *
    * Update a mass-payment.
    *
-   * @param UpdateJobRequestBody $body Mass-payment to update. (required)
+   * @param models\UpdateJobRequestBody $body Mass-payment to update. (required)
    * @param string $id ID of mass-payment to update (required)
-   * @return MassPayment
+   * @return models\MassPayment
+   * @throws ApiException
    */
    public function update($body, $id) {
 

--- a/lib/OndemandauthorizationsApi.php
+++ b/lib/OndemandauthorizationsApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class OndemandauthorizationsApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class OndemandauthorizationsApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -62,7 +75,8 @@ class OndemandauthorizationsApi {
    *
    * Create a new on-demand authorization.
    *
-   * @return Authorization
+   * @return models\Authorization
+   * @throws ApiException
    */
    public function createAuthorization() {
       

--- a/lib/RootApi.php
+++ b/lib/RootApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class RootApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class RootApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -62,7 +75,8 @@ class RootApi {
    *
    * Get root
    *
-   * @return CatalogResponse
+   * @return models\CatalogResponse
+   * @throws ApiException
    */
    public function root() {
       
@@ -112,7 +126,8 @@ class RootApi {
    *
    * OAuth get token response
    *
-   * @return OAuthResponse
+   * @return models\OAuthResponse
+   * @throws ApiException
    */
    public function oauth() {
       

--- a/lib/SandboxApi.php
+++ b/lib/SandboxApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class SandboxApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class SandboxApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -62,7 +75,8 @@ class SandboxApi {
    *
    * Simulate ach processing
    *
-   * @return ProcessResult
+   * @return models\ProcessResult
+   * @throws ApiException
    */
    public function simulations() {
 

--- a/lib/TransfersApi.php
+++ b/lib/TransfersApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class TransfersApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class TransfersApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -66,7 +79,8 @@ class TransfersApi {
    * @param int $limit How many results to return. (optional)
    * @param int $offset How many results to skip. (optional)
    * @param string $status What status to filter by. (optional)
-   * @return TransferListResponse
+   * @return models\TransferListResponse
+   * @throws ApiException
    */
    public function getAccountTransfers($id, $limit = null, $offset = null, $status = null) {
 
@@ -144,7 +158,8 @@ class TransfersApi {
    * @param int $limit How many results to return. (optional)
    * @param int $offset How many results to skip. (optional)
    * @param string $status What status to filter by. (required)
-   * @return TransferListResponse
+   * @return models\TransferListResponse
+   * @throws ApiException
    */
    public function getCustomerTransfers($id, $limit = null, $offset = null, $status = null) {
 
@@ -218,8 +233,9 @@ class TransfersApi {
    *
    * Create a new transfer.
    *
-   * @param TransferRequestBody $body Transfer request. (required)
-   * @return Unit
+   * @param models\TransferRequestBody $body Transfer request. (required)
+   * @return models\Unit
+   * @throws ApiException
    */
    public function create($body) {
 
@@ -274,7 +290,8 @@ class TransfersApi {
    * Get a transfer by id.
    *
    * @param string $id ID of transfer to get. (required)
-   * @return Transfer
+   * @return models\Transfer
+   * @throws ApiException
    */
    public function byId($id) {
 
@@ -339,9 +356,10 @@ class TransfersApi {
    *
    * Update a transfer.
    *
-   * @param UpdateTransfer $body Transfer to update. (required)
+   * @param models\UpdateTransfer $body Transfer to update. (required)
    * @param string $id ID of transfer to get. (required)
-   * @return Transfer
+   * @return models\Transfer
+   * @throws ApiException
    */
    public function update($body, $id) {
 
@@ -411,7 +429,8 @@ class TransfersApi {
    * Get a bank transfer failure by transfer id.
    *
    * @param string $id ID of failed bank transfer to get. (required)
-   * @return TransferFailure
+   * @return models\TransferFailure
+   * @throws ApiException
    */
    public function failureById($id) {
 
@@ -477,7 +496,8 @@ class TransfersApi {
    * Get a transfer's fees.
    *
    * @param string $id Transfer id to get fees for. (required)
-   * @return FeesBySourceResponse
+   * @return models\FeesBySourceResponse
+   * @throws ApiException
    */
    public function getFeesBySource($id) {
 

--- a/lib/WebhooksApi.php
+++ b/lib/WebhooksApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class WebhooksApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class WebhooksApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -65,7 +78,8 @@ class WebhooksApi {
    * @param string $id ID of webhook to get. (required)
    * @param int $limit How many results to return. (optional)
    * @param int $offset How many results to skip. (optional)
-   * @return WebhookEventListResponse
+   * @return models\WebhookEventListResponse
+   * @throws ApiException
    */
    public function hooksById($id, $limit = null, $offset = null) {
 
@@ -137,7 +151,8 @@ class WebhooksApi {
    * Get a webhook by id.
    *
    * @param string $id ID of webhook to get. (required)
-   * @return Webhook
+   * @return models\Webhook
+   * @throws ApiException
    */
    public function id($id) {
 
@@ -203,7 +218,8 @@ class WebhooksApi {
    * Get retries requested by webhook id.
    *
    * @param string $id ID of webhook to get retries for. (required)
-   * @return WebhookRetryRequestListResponse
+   * @return models\WebhookRetryRequestListResponse
+   * @throws ApiException
    */
    public function retriesById($id) {
 
@@ -269,7 +285,8 @@ class WebhooksApi {
    * Retry a webhook by id.
    *
    * @param string $id ID of webhook to retry. (required)
-   * @return WebhookRetry
+   * @return models\WebhookRetry
+   * @throws ApiException
    */
    public function retryWebhook($id) {
 

--- a/lib/WebhooksubscriptionsApi.php
+++ b/lib/WebhooksubscriptionsApi.php
@@ -24,6 +24,16 @@ namespace DwollaSwagger;
 
 class WebhooksubscriptionsApi {
 
+  /**
+   * @var ApiClient $apiClient instance of the ApiClient
+   */
+  private $apiClient;
+
+  /**
+   * @var array $authSettings array of authentication methods
+   */
+  public $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -40,17 +50,20 @@ class WebhooksubscriptionsApi {
     $this->authSettings = array('oauth2');
   }
 
-  private $apiClient; // instance of the ApiClient
 
   /**
-   * get the API client
+   * Returns an instance of the API Client
+   *
+   * @return ApiClient|null
    */
   public function getApiClient() {
     return $this->apiClient;
   }
 
   /**
-   * set the API client
+   * Set the API client
+   *
+   * @param ApiClient $apiClient
    */
   public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
@@ -62,7 +75,8 @@ class WebhooksubscriptionsApi {
    *
    * Get the list of webhooks.
    *
-   * @return WebhookListResponse
+   * @return models\WebhookListResponse
+   * @throws ApiException
    */
    public function _list() {
       
@@ -112,8 +126,9 @@ class WebhooksubscriptionsApi {
    *
    * Create a new webhook subscription.
    *
-   * @param CreateWebhook $body Webhook subscription to create. (required)
-   * @return WebhookSubscription
+   * @param models\CreateWebhook $body Webhook subscription to create. (required)
+   * @return models\WebhookSubscription
+   * @throws ApiException
    */
    public function create($body) {
       
@@ -168,7 +183,8 @@ class WebhooksubscriptionsApi {
    * Get a webhook subscription by id.
    *
    * @param string $id ID of webhook subscription to get. (required)
-   * @return WebhookSubscription
+   * @return models\WebhookSubscription
+   * @throws ApiException
    */
    public function id($id) {
       
@@ -233,9 +249,10 @@ class WebhooksubscriptionsApi {
    *
    * Update a subscription by id.
    *
-   * @param UpdateSubscription $body Details to update. (required)
+   * @param models\UpdateSubscription $body Details to update. (required)
    * @param string $id ID of webhook to update. (required)
-   * @return WebhookSubscription
+   * @return models\WebhookSubscription
+   * @throws ApiException
    */
    public function updateSubscription($body, $id) {
       
@@ -305,7 +322,8 @@ class WebhooksubscriptionsApi {
    * Delete a webhook subscription by id.
    *
    * @param string $id ID of webhook subscription to delete. (required)
-   * @return WebhookSubscription
+   * @return models\WebhookSubscription
+   * @throws ApiException
    */
    public function deleteById($id) {
       


### PR DESCRIPTION
All models are name-spaced to `DwollaSwagger\models` meaning all the PHPDocs are incorrect that use `@return <MODEL>`. 

This updates the documentation to show the correct return type.