### PR TITLE
ModelInterface addition to clean up ApiClient::deserialize call

### DIFF
--- a/.idea/dictionaries/chris.xml
+++ b/.idea/dictionaries/chris.xml
@@ -1,7 +1,0 @@
-<component name="ProjectDictionaryState">
-  <dictionary name="chris">
-    <words>
-      <w>deserialized</w>
-    </words>
-  </dictionary>
-</component>

--- a/.idea/dictionaries/chris.xml
+++ b/.idea/dictionaries/chris.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="chris">
+    <words>
+      <w>deserialized</w>
+    </words>
+  </dictionary>
+</component>

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }
   ],
   "require": {
-    "php": ">=5.3.3",
+    "php": ">=5.4.0",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*"

--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -17,6 +17,8 @@
 
 namespace DwollaSwagger;
 
+use DwollaSwagger\interfaces\ModelInterface;
+
 class ApiClient {
 
   public static $PATCH = "PATCH";
@@ -336,7 +338,8 @@ class ApiClient {
       $values = array();
       foreach (array_keys($data::$swaggerTypes) as $property) {
         if ($data->$property !== null) {
-          $values[$data::$attributeMap[$property]] = $this->sanitizeForSerialization($data->$property);
+          /** @var ModelInterface $data */
+          $values[$data::getAttributeMap()[$property]] = $this->sanitizeForSerialization($data->$property);
         }
       }
       $sanitized = $values;
@@ -446,9 +449,10 @@ class ApiClient {
       $deserialized = $data;
     } else {
       $class = "DwollaSwagger\\models\\".$class;
+      /** @var ModelInterface $instance */
       $instance = new $class();
       foreach ($instance::$swaggerTypes as $property => $type) {
-        $original_property_name = $instance::$attributeMap[$property];
+        $original_property_name = $instance::getAttributeMap()[$property];
         if (isset($original_property_name) && isset($data->$original_property_name)) {
           $instance->$property = self::deserialize($data->$original_property_name, $type);
         }

--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -448,8 +448,8 @@ class ApiClient {
       settype($data, $class);
       $deserialized = $data;
     } else {
-      $class = "DwollaSwagger\\models\\".$class;
       /** @var ModelInterface $instance */
+      $class = "DwollaSwagger\\models\\".$class;
       $instance = new $class();
       foreach ($instance::getSwaggerTypes() as $property => $type) {
         $original_property_name = $instance::getAttributeMap()[$property];

--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -336,9 +336,9 @@ class ApiClient {
       $sanitized = $data;
     } else if (is_object($data)) {
       $values = array();
-      foreach (array_keys($data::$swaggerTypes) as $property) {
+      /** @var ModelInterface $data */
+      foreach (array_keys($data::getSwaggerTypes()) as $property) {
         if ($data->$property !== null) {
-          /** @var ModelInterface $data */
           $values[$data::getAttributeMap()[$property]] = $this->sanitizeForSerialization($data->$property);
         }
       }
@@ -451,7 +451,7 @@ class ApiClient {
       $class = "DwollaSwagger\\models\\".$class;
       /** @var ModelInterface $instance */
       $instance = new $class();
-      foreach ($instance::$swaggerTypes as $property => $type) {
+      foreach ($instance::getSwaggerTypes() as $property => $type) {
         $original_property_name = $instance::getAttributeMap()[$property];
         if (isset($original_property_name) && isset($data->$original_property_name)) {
           $instance->$property = self::deserialize($data->$original_property_name, $type);

--- a/lib/interfaces/ModelInterface.php
+++ b/lib/interfaces/ModelInterface.php
@@ -9,7 +9,7 @@
 namespace DwollaSwagger\interfaces;
 
 
-interface iModel
+interface ModelInterface
 {
   /**
    * @return array Get Swagger Types

--- a/lib/interfaces/iModel.php
+++ b/lib/interfaces/iModel.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: chris
+ * Date: 2019-02-27
+ * Time: 15:30
+ */
+
+namespace DwollaSwagger\interfaces;
+
+
+interface iModel
+{
+  /**
+   * @return array Get Swagger Types
+   */
+  static function getSwaggerTypes();
+
+  /**
+   * @return array Get array of attributes
+   */
+  static function getAttributeMap();
+
+  public function offsetExists($offset);
+  public function offsetGet($offset);
+  public function offsetSet($offset, $value);
+  public function offsetUnset($offset);
+}

--- a/lib/interfaces/iModel.php
+++ b/lib/interfaces/iModel.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: chris
+ * Created by Chris Piggott.
+ * User: cpiggott
  * Date: 2019-02-27
  * Time: 15:30
  */

--- a/lib/models/AccountInfo.php
+++ b/lib/models/AccountInfo.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class AccountInfo implements ArrayAccess {
+class AccountInfo implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       'id' => 'string',
@@ -41,7 +42,7 @@ class AccountInfo implements ArrayAccess {
       '_embedded' => '_embedded'
   );
 
-  
+
   public $_links; /* map[string,HalLink] */
   public $id; /* string */
   public $name; /* string */
@@ -52,6 +53,22 @@ class AccountInfo implements ArrayAccess {
     $this->id = $data["id"];
     $this->name = $data["name"];
     $this->_embedded = $data["_embedded"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/AccountOAuthToken.php
+++ b/lib/models/AccountOAuthToken.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class AccountOAuthToken implements ArrayAccess {
+class AccountOAuthToken implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class AccountOAuthToken implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->token = $data["token"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Address.php
+++ b/lib/models/Address.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Address implements ArrayAccess {
+class Address implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'address1' => 'string',
       'address2' => 'string',
@@ -64,6 +65,22 @@ class Address implements ArrayAccess {
     $this->state_province_region = $data["state_province_region"];
     $this->country = $data["country"];
     $this->postal_code = $data["postal_code"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Amount.php
+++ b/lib/models/Amount.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Amount implements ArrayAccess {
+class Amount implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'value' => 'string',
       'currency' => 'string'
@@ -44,6 +45,22 @@ class Amount implements ArrayAccess {
   public function __construct(array $data = null) {
     $this->value = $data["value"];
     $this->currency = $data["currency"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/ApplicationEvent.php
+++ b/lib/models/ApplicationEvent.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class ApplicationEvent implements ArrayAccess {
+class ApplicationEvent implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -60,6 +61,22 @@ class ApplicationEvent implements ArrayAccess {
     $this->created = $data["created"];
     $this->topic = $data["topic"];
     $this->resource_id = $data["resource_id"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Authorization.php
+++ b/lib/models/Authorization.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Authorization implements ArrayAccess {
+class Authorization implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       
   );
@@ -35,10 +36,25 @@ class Authorization implements ArrayAccess {
       
   );
 
-  
 
   public function __construct(array $data = null) {
     
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/BeneficialOwnerListResponse.php
+++ b/lib/models/BeneficialOwnerListResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class BeneficialOwnerListResponse implements ArrayAccess {
+class BeneficialOwnerListResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class BeneficialOwnerListResponse implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->total = $data["total"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/BusinessClassification.php
+++ b/lib/models/BusinessClassification.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class BusinessClassification implements ArrayAccess {
+class BusinessClassification implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -52,6 +53,22 @@ class BusinessClassification implements ArrayAccess {
     $this->_embedded = $data["_embedded"];
     $this->id = $data["id"];
     $this->name = $data["name"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/BusinessClassificationListResponse.php
+++ b/lib/models/BusinessClassificationListResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class BusinessClassificationListResponse implements ArrayAccess {
+class BusinessClassificationListResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,23 @@ class BusinessClassificationListResponse implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->total = $data["total"];
+  }
+
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/CatalogResponse.php
+++ b/lib/models/CatalogResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class CatalogResponse implements ArrayAccess {
+class CatalogResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object'
@@ -44,6 +45,22 @@ class CatalogResponse implements ArrayAccess {
   public function __construct(array $data = null) {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/CertifyRequest.php
+++ b/lib/models/CertifyRequest.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class CertifyRequest implements ArrayAccess {
+class CertifyRequest implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'status' => 'string'
   );
@@ -40,6 +41,22 @@ class CertifyRequest implements ArrayAccess {
 
   public function __construct(array $data = null) {
     $this->status = $data["status"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Clearing.php
+++ b/lib/models/Clearing.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Clearing implements ArrayAccess {
+class Clearing implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'source' => 'string',
       'destination' => 'string'
@@ -44,6 +45,22 @@ class Clearing implements ArrayAccess {
   public function __construct(array $data = null) {
     $this->source = $data["source"];
     $this->destination = $data["destination"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/CreateCustomer.php
+++ b/lib/models/CreateCustomer.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class CreateCustomer implements ArrayAccess {
+class CreateCustomer implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'first_name' => 'string',
       'last_name' => 'string',
@@ -116,6 +117,22 @@ class CreateCustomer implements ArrayAccess {
     $this->doing_business_as = $data["doing_business_as"];
     $this->website = $data["website"];
     $this->controller = $data["controller"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/CreateFundingSourceRequest.php
+++ b/lib/models/CreateFundingSourceRequest.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class CreateFundingSourceRequest implements ArrayAccess {
+class CreateFundingSourceRequest implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'object',
       'routing_number' => 'string',
@@ -68,6 +69,22 @@ class CreateFundingSourceRequest implements ArrayAccess {
     $this->name = $data["name"];
     $this->verified = $data["verified"];
     $this->channels = $data["channels"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/CreateOwnerRequest.php
+++ b/lib/models/CreateOwnerRequest.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class CreateOwnerRequest implements ArrayAccess {
+class CreateOwnerRequest implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'first_name' => 'string',
       'last_name' => 'string',
@@ -60,6 +61,22 @@ class CreateOwnerRequest implements ArrayAccess {
     $this->date_of_birth = $data["date_of_birth"];
     $this->address = $data["address"];
     $this->passport = $data["passport"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/CreateWebhook.php
+++ b/lib/models/CreateWebhook.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class CreateWebhook implements ArrayAccess {
+class CreateWebhook implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'url' => 'string',
       'secret' => 'string'
@@ -44,6 +45,22 @@ class CreateWebhook implements ArrayAccess {
   public function __construct(array $data = null) {
     $this->url = $data["url"];
     $this->secret = $data["secret"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Customer.php
+++ b/lib/models/Customer.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Customer implements ArrayAccess {
+class Customer implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -112,6 +113,22 @@ class Customer implements ArrayAccess {
     $this->doing_business_as = $data["doing_business_as"];
     $this->website = $data["website"];
     $this->controller = $data["controller"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/CustomerListResponse.php
+++ b/lib/models/CustomerListResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class CustomerListResponse implements ArrayAccess {
+class CustomerListResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class CustomerListResponse implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->total = $data["total"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/CustomerOAuthToken.php
+++ b/lib/models/CustomerOAuthToken.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class CustomerOAuthToken implements ArrayAccess {
+class CustomerOAuthToken implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class CustomerOAuthToken implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->token = $data["token"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Document.php
+++ b/lib/models/Document.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Document implements ArrayAccess {
+class Document implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       'id' => 'string',
@@ -64,6 +65,22 @@ class Document implements ArrayAccess {
     $this->created = $data["created"];
     $this->failure_reason = $data["failure_reason"];
     $this->_embedded = $data["_embedded"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/DocumentListResponse.php
+++ b/lib/models/DocumentListResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class DocumentListResponse implements ArrayAccess {
+class DocumentListResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class DocumentListResponse implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->total = $data["total"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/EventListResponse.php
+++ b/lib/models/EventListResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class EventListResponse implements ArrayAccess {
+class EventListResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class EventListResponse implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->total = $data["total"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/FacilitatorFeeRequest.php
+++ b/lib/models/FacilitatorFeeRequest.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class FacilitatorFeeRequest implements ArrayAccess {
+class FacilitatorFeeRequest implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       'amount' => 'Amount'
@@ -44,6 +45,22 @@ class FacilitatorFeeRequest implements ArrayAccess {
   public function __construct(array $data = null) {
     $this->_links = $data["_links"];
     $this->amount = $data["amount"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/FailureDetails.php
+++ b/lib/models/FailureDetails.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class FailureDetails implements ArrayAccess {
+class FailureDetails implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'code' => 'string',
       'description' => 'string'
@@ -44,6 +45,22 @@ class FailureDetails implements ArrayAccess {
   public function __construct(array $data = null) {
     $this->code = $data["code"];
     $this->description = $data["description"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/FeesBySourceResponse.php
+++ b/lib/models/FeesBySourceResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class FeesBySourceResponse implements ArrayAccess {
+class FeesBySourceResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -52,6 +53,22 @@ class FeesBySourceResponse implements ArrayAccess {
     $this->_embedded = $data["_embedded"];
     $this->transactions = $data["transactions"];
     $this->total = $data["total"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/FullAccountInfo.php
+++ b/lib/models/FullAccountInfo.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class FullAccountInfo implements ArrayAccess {
+class FullAccountInfo implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       'id' => 'string',
@@ -60,6 +61,22 @@ class FullAccountInfo implements ArrayAccess {
     $this->timezone_offset = $data["timezone_offset"];
     $this->type = $data["type"];
     $this->_embedded = $data["_embedded"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/FundingSource.php
+++ b/lib/models/FundingSource.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class FundingSource implements ArrayAccess {
+class FundingSource implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -92,6 +93,22 @@ class FundingSource implements ArrayAccess {
     $this->bank_name = $data["bank_name"];
     $this->iav_account_holders = $data["iav_account_holders"];
     $this->fingerprint = $data["fingerprint"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/FundingSourceBalance.php
+++ b/lib/models/FundingSourceBalance.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class FundingSourceBalance implements ArrayAccess {
+class FundingSourceBalance implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -56,6 +57,22 @@ class FundingSourceBalance implements ArrayAccess {
     $this->balance = $data["balance"];
     $this->last_updated = $data["last_updated"];
     $this->status = $data["status"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/FundingSourceListResponse.php
+++ b/lib/models/FundingSourceListResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class FundingSourceListResponse implements ArrayAccess {
+class FundingSourceListResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object'
@@ -44,6 +45,22 @@ class FundingSourceListResponse implements ArrayAccess {
   public function __construct(array $data = null) {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/HalLink.php
+++ b/lib/models/HalLink.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class HalLink implements ArrayAccess {
+class HalLink implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'href' => 'string',
       'type' => 'string',
@@ -48,6 +49,22 @@ class HalLink implements ArrayAccess {
     $this->href = $data["href"];
     $this->type = $data["type"];
     $this->resource_type = $data["resource_type"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/IavToken.php
+++ b/lib/models/IavToken.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class IavToken implements ArrayAccess {
+class IavToken implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class IavToken implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->token = $data["token"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Id.php
+++ b/lib/models/Id.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Id implements ArrayAccess {
+class Id implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       
   );
@@ -39,6 +40,22 @@ class Id implements ArrayAccess {
 
   public function __construct(array $data = null) {
     
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/MassPayment.php
+++ b/lib/models/MassPayment.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class MassPayment implements ArrayAccess {
+class MassPayment implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'object',
       '_embedded' => 'object',
@@ -72,6 +73,22 @@ class MassPayment implements ArrayAccess {
     $this->total = $data["total"];
     $this->total_fees = $data["total_fees"];
     $this->correlation_id = $data["correlation_id"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/MassPaymentItem.php
+++ b/lib/models/MassPaymentItem.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class MassPaymentItem implements ArrayAccess {
+class MassPaymentItem implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'object',
       '_embedded' => 'object',
@@ -64,6 +65,22 @@ class MassPaymentItem implements ArrayAccess {
     $this->amount = $data["amount"];
     $this->metadata = $data["metadata"];
     $this->correlation_id = $data["correlation_id"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/MassPaymentItemListResponse.php
+++ b/lib/models/MassPaymentItemListResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class MassPaymentItemListResponse implements ArrayAccess {
+class MassPaymentItemListResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class MassPaymentItemListResponse implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->total = $data["total"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/MassPaymentItemRequestBody.php
+++ b/lib/models/MassPaymentItemRequestBody.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class MassPaymentItemRequestBody implements ArrayAccess {
+class MassPaymentItemRequestBody implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'object',
       'amount' => 'Amount',
@@ -52,6 +53,22 @@ class MassPaymentItemRequestBody implements ArrayAccess {
     $this->amount = $data["amount"];
     $this->metadata = $data["metadata"];
     $this->correlation_id = $data["correlation_id"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/MassPaymentListResponse.php
+++ b/lib/models/MassPaymentListResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class MassPaymentListResponse implements ArrayAccess {
+class MassPaymentListResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class MassPaymentListResponse implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->total = $data["total"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/MassPaymentRequestBody.php
+++ b/lib/models/MassPaymentRequestBody.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class MassPaymentRequestBody implements ArrayAccess {
+class MassPaymentRequestBody implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'object',
       'items' => 'array[MassPaymentItemRequestBody]',
@@ -56,6 +57,22 @@ class MassPaymentRequestBody implements ArrayAccess {
     $this->metadata = $data["metadata"];
     $this->status = $data["status"];
     $this->correlation_id = $data["correlation_id"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/MicroDeposits.php
+++ b/lib/models/MicroDeposits.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class MicroDeposits implements ArrayAccess {
+class MicroDeposits implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object'
@@ -44,6 +45,22 @@ class MicroDeposits implements ArrayAccess {
   public function __construct(array $data = null) {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/MicroDepositsInitiated.php
+++ b/lib/models/MicroDepositsInitiated.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class MicroDepositsInitiated implements ArrayAccess {
+class MicroDepositsInitiated implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -56,6 +57,22 @@ class MicroDepositsInitiated implements ArrayAccess {
     $this->created = $data["created"];
     $this->status = $data["status"];
     $this->failure = $data["failure"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Money.php
+++ b/lib/models/Money.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Money implements ArrayAccess {
+class Money implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'value' => 'string',
       'currency' => 'string'
@@ -44,6 +45,22 @@ class Money implements ArrayAccess {
   public function __construct(array $data = null) {
     $this->value = $data["value"];
     $this->currency = $data["currency"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/OAuthResponse.php
+++ b/lib/models/OAuthResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class OAuthResponse implements ArrayAccess {
+class OAuthResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       'access_token' => 'string',
@@ -64,6 +65,22 @@ class OAuthResponse implements ArrayAccess {
     $this->refresh_expires_in = $data["refresh_expires_in"];
     $this->token_type = $data["token_type"];
     $this->scope = $data["scope"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Owner.php
+++ b/lib/models/Owner.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Owner implements ArrayAccess {
+class Owner implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       'id' => 'string',
@@ -64,6 +65,22 @@ class Owner implements ArrayAccess {
     $this->address = $data["address"];
     $this->verification_status = $data["verification_status"];
     $this->_embedded = $data["_embedded"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Ownership.php
+++ b/lib/models/Ownership.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Ownership implements ArrayAccess {
+class Ownership implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       'status' => 'string',
@@ -48,6 +49,23 @@ class Ownership implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->status = $data["status"];
     $this->_embedded = $data["_embedded"];
+  }
+
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Passport.php
+++ b/lib/models/Passport.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Passport implements ArrayAccess {
+class Passport implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'number' => 'string',
       'country' => 'string'
@@ -44,6 +45,22 @@ class Passport implements ArrayAccess {
   public function __construct(array $data = null) {
     $this->number = $data["number"];
     $this->country = $data["country"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/ProcessResult.php
+++ b/lib/models/ProcessResult.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class ProcessResult implements ArrayAccess {
+class ProcessResult implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'object',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class ProcessResult implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->total = $data["total"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/RemoveBankRequest.php
+++ b/lib/models/RemoveBankRequest.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class RemoveBankRequest implements ArrayAccess {
+class RemoveBankRequest implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'removed' => 'boolean'
   );
@@ -40,6 +41,22 @@ class RemoveBankRequest implements ArrayAccess {
 
   public function __construct(array $data = null) {
     $this->removed = $data["removed"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Transfer.php
+++ b/lib/models/Transfer.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Transfer implements ArrayAccess {
+class Transfer implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -76,6 +77,22 @@ class Transfer implements ArrayAccess {
     $this->clearing = $data["clearing"];
     $this->correlation_id = $data["correlation_id"];
     $this->individual_ach_id = $data["individual_ach_id"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/TransferFailure.php
+++ b/lib/models/TransferFailure.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class TransferFailure implements ArrayAccess {
+class TransferFailure implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -60,6 +61,22 @@ class TransferFailure implements ArrayAccess {
     $this->description = $data["description"];
     $this->explanation = $data["explanation"];
     $this->created = $data["created"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/TransferListResponse.php
+++ b/lib/models/TransferListResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class TransferListResponse implements ArrayAccess {
+class TransferListResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class TransferListResponse implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->total = $data["total"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/TransferRequestBody.php
+++ b/lib/models/TransferRequestBody.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class TransferRequestBody implements ArrayAccess {
+class TransferRequestBody implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       'amount' => 'Amount',
@@ -64,6 +65,22 @@ class TransferRequestBody implements ArrayAccess {
     $this->clearing = $data["clearing"];
     $this->imad = $data["imad"];
     $this->correlation_id = $data["correlation_id"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Unit.php
+++ b/lib/models/Unit.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Unit implements ArrayAccess {
+class Unit implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       
   );
@@ -39,6 +40,22 @@ class Unit implements ArrayAccess {
 
   public function __construct(array $data = null) {
     
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/UpdateBankRequest.php
+++ b/lib/models/UpdateBankRequest.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class UpdateBankRequest implements ArrayAccess {
+class UpdateBankRequest implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'object',
       'name' => 'string',
@@ -56,6 +57,22 @@ class UpdateBankRequest implements ArrayAccess {
     $this->routing_number = $data["routing_number"];
     $this->account_number = $data["account_number"];
     $this->bank_account_type = $data["bank_account_type"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/UpdateCustomer.php
+++ b/lib/models/UpdateCustomer.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class UpdateCustomer implements ArrayAccess {
+class UpdateCustomer implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'first_name' => 'string',
       'last_name' => 'string',
@@ -120,6 +121,22 @@ class UpdateCustomer implements ArrayAccess {
     $this->doing_business_as = $data["doing_business_as"];
     $this->website = $data["website"];
     $this->controller = $data["controller"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/UpdateJobRequestBody.php
+++ b/lib/models/UpdateJobRequestBody.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class UpdateJobRequestBody implements ArrayAccess {
+class UpdateJobRequestBody implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'status' => 'string'
   );
@@ -40,6 +41,22 @@ class UpdateJobRequestBody implements ArrayAccess {
 
   public function __construct(array $data = null) {
     $this->status = $data["status"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/UpdateOwnerRequest.php
+++ b/lib/models/UpdateOwnerRequest.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class UpdateOwnerRequest implements ArrayAccess {
+class UpdateOwnerRequest implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'first_name' => 'string',
       'last_name' => 'string',
@@ -60,6 +61,22 @@ class UpdateOwnerRequest implements ArrayAccess {
     $this->date_of_birth = $data["date_of_birth"];
     $this->address = $data["address"];
     $this->passport = $data["passport"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/UpdateSubscription.php
+++ b/lib/models/UpdateSubscription.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class UpdateSubscription implements ArrayAccess {
+class UpdateSubscription implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'paused' => 'boolean'
   );
@@ -40,6 +41,22 @@ class UpdateSubscription implements ArrayAccess {
 
   public function __construct(array $data = null) {
     $this->paused = $data["paused"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/UpdateTransfer.php
+++ b/lib/models/UpdateTransfer.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class UpdateTransfer implements ArrayAccess {
+class UpdateTransfer implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'status' => 'string'
   );
@@ -40,6 +41,22 @@ class UpdateTransfer implements ArrayAccess {
 
   public function __construct(array $data = null) {
     $this->status = $data["status"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/VerifyMicroDepositsRequest.php
+++ b/lib/models/VerifyMicroDepositsRequest.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class VerifyMicroDepositsRequest implements ArrayAccess {
+class VerifyMicroDepositsRequest implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'amount1' => 'Amount',
       'amount2' => 'Amount'
@@ -44,6 +45,22 @@ class VerifyMicroDepositsRequest implements ArrayAccess {
   public function __construct(array $data = null) {
     $this->amount1 = $data["amount1"];
     $this->amount2 = $data["amount2"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/Webhook.php
+++ b/lib/models/Webhook.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class Webhook implements ArrayAccess {
+class Webhook implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -68,6 +69,22 @@ class Webhook implements ArrayAccess {
     $this->event_id = $data["event_id"];
     $this->subscription_id = $data["subscription_id"];
     $this->attempts = $data["attempts"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/WebhookAttempt.php
+++ b/lib/models/WebhookAttempt.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class WebhookAttempt implements ArrayAccess {
+class WebhookAttempt implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'id' => 'string',
       'request' => 'WebhookHttpRequest',
@@ -48,6 +49,22 @@ class WebhookAttempt implements ArrayAccess {
     $this->id = $data["id"];
     $this->request = $data["request"];
     $this->response = $data["response"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/WebhookEventListResponse.php
+++ b/lib/models/WebhookEventListResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class WebhookEventListResponse implements ArrayAccess {
+class WebhookEventListResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class WebhookEventListResponse implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->total = $data["total"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/WebhookHeader.php
+++ b/lib/models/WebhookHeader.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class WebhookHeader implements ArrayAccess {
+class WebhookHeader implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'name' => 'string',
       'value' => 'string'
@@ -44,6 +45,22 @@ class WebhookHeader implements ArrayAccess {
   public function __construct(array $data = null) {
     $this->name = $data["name"];
     $this->value = $data["value"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/WebhookHttpRequest.php
+++ b/lib/models/WebhookHttpRequest.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class WebhookHttpRequest implements ArrayAccess {
+class WebhookHttpRequest implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'timestamp' => 'DateTime',
       'url' => 'string',
@@ -52,6 +53,22 @@ class WebhookHttpRequest implements ArrayAccess {
     $this->url = $data["url"];
     $this->headers = $data["headers"];
     $this->body = $data["body"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/WebhookHttpResponse.php
+++ b/lib/models/WebhookHttpResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class WebhookHttpResponse implements ArrayAccess {
+class WebhookHttpResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       'timestamp' => 'DateTime',
       'headers' => 'array[WebhookHeader]',
@@ -52,6 +53,22 @@ class WebhookHttpResponse implements ArrayAccess {
     $this->headers = $data["headers"];
     $this->status_code = $data["status_code"];
     $this->body = $data["body"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/WebhookListResponse.php
+++ b/lib/models/WebhookListResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class WebhookListResponse implements ArrayAccess {
+class WebhookListResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class WebhookListResponse implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->total = $data["total"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/WebhookRetry.php
+++ b/lib/models/WebhookRetry.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class WebhookRetry implements ArrayAccess {
+class WebhookRetry implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -52,6 +53,22 @@ class WebhookRetry implements ArrayAccess {
     $this->_embedded = $data["_embedded"];
     $this->id = $data["id"];
     $this->timestamp = $data["timestamp"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/WebhookRetryRequestListResponse.php
+++ b/lib/models/WebhookRetryRequestListResponse.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class WebhookRetryRequestListResponse implements ArrayAccess {
+class WebhookRetryRequestListResponse implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -48,6 +49,22 @@ class WebhookRetryRequestListResponse implements ArrayAccess {
     $this->_links = $data["_links"];
     $this->_embedded = $data["_embedded"];
     $this->total = $data["total"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {

--- a/lib/models/WebhookSubscription.php
+++ b/lib/models/WebhookSubscription.php
@@ -25,8 +25,9 @@
 namespace DwollaSwagger\models;
 
 use \ArrayAccess;
+use DwollaSwagger\interfaces\ModelInterface;
 
-class WebhookSubscription implements ArrayAccess {
+class WebhookSubscription implements ArrayAccess, ModelInterface {
   static $swaggerTypes = array(
       '_links' => 'map[string,HalLink]',
       '_embedded' => 'object',
@@ -60,6 +61,22 @@ class WebhookSubscription implements ArrayAccess {
     $this->url = $data["url"];
     $this->paused = $data["paused"];
     $this->created = $data["created"];
+  }
+
+  /**
+   * @return array static $swaggerTypes swagger types
+   */
+  public static function getSwaggerTypes()
+  {
+    return self::$swaggerTypes;
+  }
+
+  /**
+   * @return array static $attributeMap attribute map
+   */
+  public static function getAttributeMap()
+  {
+    return self::$attributeMap;
   }
 
   public function offsetExists($offset) {


### PR DESCRIPTION
I added a `ModelInterface` to clean up the calls that used unknown variables in the `ApiClient::deserialize` call for Swagger based models. 

This removes "breaking" errors when running a php code-sniffer to check for inconsistencies throughout the code-base. 

I was unable to find any tests to run this against, so if you have them on your end and would like to test them, please let me know if you find any issue and I'll be happy to clean them up. 