### PR TITLE
DEV-1433: Add support for creating a verified funding source using a plaidToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ try{
 
 ## Changelog
 
+- [**1.9.0**](https://github.com/Dwolla/dwolla-swagger-php/releases/tag/1.9.0): Add support for creating bank funding source using a `plaidToken` for a customer.
 - [**1.8.0**](https://github.com/Dwolla/dwolla-swagger-php/releases/tag/1.8.0): Add Exchanges and Exchange Partners API methods.
 - [**1.7.1**](https://github.com/Dwolla/dwolla-swagger-php/releases/tag/1.7.1): Fix bug around on-demand authorizations not parsing Dwolla response correctly.
 - [**1.7.0**](https://github.com/Dwolla/dwolla-swagger-php/releases/tag/1.7.0): New `getCustomerCardToken` method added to `CustomersAPI` for creating a card funding sources token for a customer.

--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -35,7 +35,7 @@ class ApiClient {
   /*
    * @var string user agent of the HTTP request, set to "PHP-Swagger" by default
    */
-  protected $user_agent = "php-swagger-1.8.0";
+  protected $user_agent = "php-swagger-1.9.0";
 
   /**
    * @param string $host Base url of the API server (optional)
@@ -194,7 +194,7 @@ class ApiClient {
 
           $headerParams['Authorization'] = 'Bearer ' . Configuration::$access_token;
           break;
-          
+
         case 'basicAuth':
           $authString = Configuration::$username . ":" . Configuration::$password;
           $headerParams['Authorization'] = 'Basic ' . base64_encode($authString);

--- a/lib/models/CreateFundingSourceRequest.php
+++ b/lib/models/CreateFundingSourceRequest.php
@@ -35,7 +35,8 @@ class CreateFundingSourceRequest implements ArrayAccess {
       'bank_account_type' => 'string',
       'name' => 'string',
       'verified' => 'boolean',
-      'channels' => 'array[string]'
+      'channels' => 'array[string]',
+      'plaid_token' => 'string'
   );
 
   static $attributeMap = array(
@@ -46,7 +47,8 @@ class CreateFundingSourceRequest implements ArrayAccess {
       'bank_account_type' => 'bankAccountType',
       'name' => 'name',
       'verified' => 'verified',
-      'channels' => 'channels'
+      'channels' => 'channels',
+      'plaid_token' => 'plaidToken'
   );
 
 
@@ -58,6 +60,7 @@ class CreateFundingSourceRequest implements ArrayAccess {
   public $name; /* string */
   public $verified; /* boolean */
   public $channels; /* array[string] */
+  public $plaid_token; /* string */
 
   public function __construct(array $data = null) {
     $this->_links = isset($data["_links"]) ? $data["_links"] : null;
@@ -68,6 +71,7 @@ class CreateFundingSourceRequest implements ArrayAccess {
     $this->name = isset($data["name"]) ? $data["name"] : null;
     $this->verified = isset($data["verified"]) ? $data["verified"] : null;
     $this->channels = isset($data["channels"]) ? $data["channels"] : null;
+    $this->plaid_token = isset($data["plaid_token"]) ? $data["plaid_token"] : null;
   }
 
   public function offsetExists($offset) {


### PR DESCRIPTION
Example code for testing adding a funding-source using plaidToken.
```php
// test.php

<?php

require('./vendor/autoload.php');

use DwollaSwagger\ApiClient;
use DwollaSwagger\Configuration;
use DwollaSwagger\OndemandauthorizationsApi;
use DwollaSwagger\TokensApi;

// Initial SDK configuration
Configuration::$username = "your_api_key";
Configuration::$password = "your_api_secret";
$apiClient = new ApiClient("https://api-sandbox.dwolla.com");


// Update our token
$tokenApi = new TokensApi($apiClient);
Configuration::$access_token = $tokenApi->token()->access_token;

// Create a plaid verified bank account
try {
    $fundingApi = new DwollaSwagger\FundingsourcesApi($apiClient);
    $fundingSource = $fundingApi->createCustomerFundingSource([
        "plaidToken" => "processor-sandbox-2de8df4f-0433-4454-b004-97f161468947",
        "name" => "Plaid Bank 1"
    ], "https://api-sandbox.dwolla.com/customers/{{your_customer_id}}");
    echo "Body: " . json_encode($fundingSource);
} catch (Exception $e) {
    echo 'Caught exception: ',  $e->getResponseBody(), "\n";
}

?>
```