### PR TITLE
setting properties to avoid deprecated dynamic properties issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Temporary PHP 7.4 support was added using these replacements:
 Additionally, temporary PHP 8.1 support was added using these replacements:
 - `([^\n]*public function (offsetExists|offsetGet|offsetSet|offsetUnset))` into `  #\[\\ReturnTypeWillChange\]\n$1`
 
+Temporary PHP 8.2 support has been added
+
 ## Table of Contents
 
 - [Getting Started](#getting-started)

--- a/lib/AccountsApi.php
+++ b/lib/AccountsApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class AccountsApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -37,6 +37,8 @@ class ApiClient {
    */
   protected $user_agent = "php-swagger-1.9.1";
 
+  protected $host;
+
   /**
    * @param string $host Base url of the API server (optional)
    */

--- a/lib/BeneficialownersApi.php
+++ b/lib/BeneficialownersApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class BeneficialownersApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/BusinessclassificationsApi.php
+++ b/lib/BusinessclassificationsApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class BusinessclassificationsApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/CustomersApi.php
+++ b/lib/CustomersApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class CustomersApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/DocumentsApi.php
+++ b/lib/DocumentsApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class DocumentsApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/EventsApi.php
+++ b/lib/EventsApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class EventsApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/ExchangepartnersApi.php
+++ b/lib/ExchangepartnersApi.php
@@ -27,6 +27,8 @@ use DwollaSwagger\models\ExchangePartnerListResponse;
 
 class ExchangepartnersApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/ExchangesApi.php
+++ b/lib/ExchangesApi.php
@@ -28,6 +28,8 @@ use DwollaSwagger\models\ExchangeListResponse;
 
 class ExchangesApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/FundingsourcesApi.php
+++ b/lib/FundingsourcesApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class FundingsourcesApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/KbaApi.php
+++ b/lib/KbaApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class KbaApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/LabelreallocationsApi.php
+++ b/lib/LabelreallocationsApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class LabelreallocationsApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/LabelsApi.php
+++ b/lib/LabelsApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class LabelsApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/LedgerentriesApi.php
+++ b/lib/LedgerentriesApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class LedgerentriesApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/MasspaymentitemsApi.php
+++ b/lib/MasspaymentitemsApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class MasspaymentitemsApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/MasspaymentsApi.php
+++ b/lib/MasspaymentsApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class MasspaymentsApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/OndemandauthorizationsApi.php
+++ b/lib/OndemandauthorizationsApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class OndemandauthorizationsApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/RootApi.php
+++ b/lib/RootApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class RootApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/SandboxApi.php
+++ b/lib/SandboxApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class SandboxApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/TokensApi.php
+++ b/lib/TokensApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class TokensApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/TransfersApi.php
+++ b/lib/TransfersApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class TransfersApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/WebhooksApi.php
+++ b/lib/WebhooksApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class WebhooksApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {

--- a/lib/WebhooksubscriptionsApi.php
+++ b/lib/WebhooksubscriptionsApi.php
@@ -24,6 +24,8 @@ namespace DwollaSwagger;
 
 class WebhooksubscriptionsApi {
 
+  protected $authSettings;
+
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {


### PR DESCRIPTION
This adds protected properties for all objects to avoid the following deprecation warning: `Creation of dynamic property DwollaSwagger\xxxxxxApi::$authSettings is deprecated`

This gets rid of all deprecation warnings related to PHP8.2